### PR TITLE
Fixing "algorithms should be set"

### DIFF
--- a/bingo-api/routes/index.js
+++ b/bingo-api/routes/index.js
@@ -5,7 +5,8 @@ require('dotenv').config();
 
 const auth = jwt({
 	secret: process.env.DB_SECRET,
-	userProperty: 'payload'
+	userProperty: 'payload',
+	algorithms: ["HS256"]
 });
 
 // Back office app


### PR DESCRIPTION
Fixing an issue with newer NodeJS versions that now require an additional settings, as Documented by https://github.com/auth0/express-jwt#required-parameters

`algorithms: ["HS256"]`

This should be set when using jwt